### PR TITLE
Added "G2E Toolhead and Entry Sensor" mod link

### DIFF
--- a/Recommended_Options/Toolhead_Modifications/README.md
+++ b/Recommended_Options/Toolhead_Modifications/README.md
@@ -81,7 +81,7 @@ Here are the STLs for popular Toolhead/Extruder combinations.  Note that this is
   </tr>
   <tr>
     <td>Galileo 2</td>
-    <td></td>
+    <td><a href="https://github.com/juliusjj25/G2E-Filametrix-Lever-Switch-Mod">Toolhead and Entry Sensor</a></td>
     <td></td>
     <td></td>
     <td></td>


### PR DESCRIPTION
https://github.com/juliusjj25/G2E-Filametrix-Lever-Switch-Mod
This mod uses only Omron D2F-L3 without balls 5.5mm.
Mod supports Toolhead Sensor and Entry Sensor.